### PR TITLE
管理者ページの作成＆店舗一覧・登録・編集・削除機能を実装

### DIFF
--- a/app/assets/stylesheets/application.tailwind.css
+++ b/app/assets/stylesheets/application.tailwind.css
@@ -1,3 +1,100 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+body {
+    background-color: lightblue;
+  }
+  
+  
+    /* ヘッダー */
+    .header {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      padding: 15px 0;
+      border-bottom: 2px solid #ccc;
+    }
+  
+    .nav .btn {
+      margin-left: 10px;
+      padding: 8px 15px;
+      text-decoration: none;
+      border-radius: 5px;
+    }
+  
+    .btn.login {
+      background-color: #007bff;
+      color: white;
+    }
+  
+    .btn.signup {
+      background-color: #28a745;
+      color: white;
+    }
+  
+    .btn.logout {
+      background-color: #dc3545;
+      color: white;
+    }
+  
+    /* 検索ボックス */
+    .search-box {
+      text-align: center;
+      padding: 20px;
+      background: #fffae6;
+      margin-top: 20px;
+      border-radius: 10px;
+    }
+  
+    .search-box h2 {
+      margin-bottom: 10px;
+    }
+  
+    .search-options, .genre-options {
+      margin: 10px 0;
+    }
+  
+    .btn.search {
+      background-color: #f8c102;
+      border: none;
+      padding: 10px 20px;
+      border-radius: 5px;
+      font-size: 16px;
+    }
+  
+    /* 店舗リスト */
+    .store-list {
+      text-align: center;
+      margin-top: 30px;
+    }
+  
+    .stores {
+      display: flex;
+      justify-content: space-around;
+      margin-top: 20px;
+    }
+  
+    .store {
+      width: 30%;
+      border: 1px solid #ddd;
+      padding: 10px;
+      border-radius: 10px;
+      text-align: center;
+    }
+  
+    .store img {
+      width: 100%;
+      height: auto;
+      border-radius: 10px;
+    }
+  
+    /* フッター */
+    .footer {
+      text-align: center;
+  
+      margin-top: 30px;
+      padding: 20px 0;
+      border-top: 2px solid #ccc;
+    }
+  

--- a/app/assets/stylesheets/home.scss
+++ b/app/assets/stylesheets/home.scss
@@ -23,7 +23,7 @@ body {
     background-color: #007bff;
     color: white;
   }
-  
+
   .btn.signup {
     background-color: #28a745;
     color: white;

--- a/app/controllers/admin/stores_controller.rb
+++ b/app/controllers/admin/stores_controller.rb
@@ -1,0 +1,67 @@
+class Admin::StoresController < ApplicationController
+    # ログインしていないユーザーをログインページにリダイレクト
+    before_action :authenticate_user!
+    # 管理者以外をroot_pathにリダイレクト
+    before_action :authorize_admin
+    # edit,update,destroyアクションの前に@storeの情報を取得
+    before_action :set_store, only: [ :edit, :update, :destroy ]
+
+    # 店舗一覧（storesを取得してindex.html.erbに渡してる）
+    def index
+      @stores = Store.all.order(id: "ASC")
+    end
+
+    # 新しい店舗作成（空の@storeインスタンスを作成してnew.html.erbに渡す）
+    def new
+      @store = Store.new
+    end
+
+    # 店舗情報を保存
+    def create
+      @store = Store.new(store_params)
+      if @store.save
+        redirect_to admin_stores_path, notice: "店舗を登録しました。"
+      else
+        render :new, status: :unprocessable_entity
+      end
+    end
+
+    # 既存の店舗情報を編集
+    def edit
+    end
+
+    # 店舗情報を更新
+    # 成功時はadmin_stores_pathにリダイレクトして通知 (flash[:notice])
+    # 失敗時はedit.html.erbを再表示→エラーメッセージを表示
+    def update
+      if @store.update(store_params)
+        redirect_to admin_stores_path, notice: "店舗情報を更新しました。"
+      else
+        render :edit, status: :unprocessable_entity
+      end
+    end
+
+    # 店情報削除
+    # 成功したらadmin_stores_pathにリダイレクトして、通知 (flash[:notice]) を表示
+    def destroy
+      @store.destroy
+      redirect_to admin_stores_path, notice: "店舗情報を削除しました。"
+    end
+
+    private
+
+    # before_actionでedit,update,destroyで呼び出される
+    def set_store
+      @store = Store.find(params[:id])
+    end
+
+    # ストリングパラメーター
+    def store_params
+      params.require(:store).permit(:store_name, :category, :address, :phone_number, :hours)
+    end
+
+    # 管理者のみアクセス許可
+    def authorize_admin
+      redirect_to root_path, alert: "管理者権限が必要です。" unless current_user.admin?
+    end
+end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -4,7 +4,7 @@ class ApplicationController < ActionController::Base
   protected
 
   def configure_permitted_parameters
-    devise_parameter_sanitizer.permit(:sign_up, keys: [:name, :email, :password, :password_confirmation])
-    devise_parameter_sanitizer.permit(:sign_in, keys: [:login, :password])
+    devise_parameter_sanitizer.permit(:sign_up, keys: [ :name, :email, :password, :password_confirmation ])
+    devise_parameter_sanitizer.permit(:sign_in, keys: [ :login, :password ])
   end
 end

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -1,5 +1,5 @@
 class HomeController < ApplicationController
   def index
-    @stores = Store.all #storeモデルから全ての店舗を取得
+    @stores = Store.where(store_name: "gohan") # storeモデルから全ての店舗を取得
   end
 end

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
 class Users::RegistrationsController < Devise::RegistrationsController
-  before_action :configure_sign_up_params, only: [:create]
-  before_action :configure_account_update_params, only: [:update]
+  before_action :configure_sign_up_params, only: [ :create ]
+  before_action :configure_account_update_params, only: [ :update ]
 
   # GET /resource/sign_up
   # def new
@@ -40,22 +40,22 @@ class Users::RegistrationsController < Devise::RegistrationsController
 
   protected
 
-  #If you have extra params to permit, append them to the sanitizer.
+  # If you have extra params to permit, append them to the sanitizer.
   def configure_sign_up_params
-    devise_parameter_sanitizer.permit(:sign_up, keys: [:name])
+    devise_parameter_sanitizer.permit(:sign_up, keys: [ :name ])
   end
 
-  #If you have extra params to permit, append them to the sanitizer.
+  # If you have extra params to permit, append them to the sanitizer.
   def configure_account_update_params
-    devise_parameter_sanitizer.permit(:account_update, keys: [:name])
+    devise_parameter_sanitizer.permit(:account_update, keys: [ :name ])
   end
 
-  #The path used after sign up.新規登録後の遷移先
+  # The path used after sign up.新規登録後の遷移先
   def after_sign_up_path_for(resource)
     root_path
   end
 
-  #The path used after sign up for inactive accounts.
+  # The path used after sign up for inactive accounts.
   def after_inactive_sign_up_path_for(resource)
     posts_path
   end

--- a/app/helpers/admin/stores_helper.rb
+++ b/app/helpers/admin/stores_helper.rb
@@ -1,0 +1,2 @@
+module Admin::StoresHelper
+end

--- a/app/models/store.rb
+++ b/app/models/store.rb
@@ -1,2 +1,12 @@
 class Store < ApplicationRecord
+    # 店のカテゴリー管理
+    enum category: { Family_restaurant: 0, Western_food: 1, Japanese_food: 2, Chinese_food: 3, cafe: 4 }
+    # 必須情報
+    validates :store_name, presence: true
+
+    #カテゴリi18nの設定
+    def category_i18n
+        I18n.t("activerecord.attributes.store.categories.#{category}", locale: :ja)
+    end
+
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -12,6 +12,6 @@ class User < ApplicationRecord
   def self.find_for_authentication(warden_conditions)
     conditions = warden_conditions.dup
     login = conditions.delete(:login)
-    where(conditions.to_h).where(["name = :value OR email = :value", { value: login }]).first
+    where(conditions.to_h).where([ "name = :value OR email = :value", { value: login } ]).first
   end
 end

--- a/app/views/admin/stores/_form.html.erb
+++ b/app/views/admin/stores/_form.html.erb
@@ -1,0 +1,33 @@
+<%= form_with(model: [:admin, @store], local: true) do |f| %>
+  <div class="mb-4">
+    <%= f.label :store_name, "店舗名", class: "block font-bold" %>
+    <%= f.text_field :store_name, class: "form-input w-full border border-gray-300 rounded-md p-2" %>
+  </div>
+
+  <div class="mb-4">
+  <%= f.label :category, "カテゴリー", class: "block font-bold" %>
+  <%= f.select :category, Store.categories.keys.map { |c| [Store.new(category: c).category_i18n, c] }, {}, class: "form-select w-full border border-gray-300 rounded-md p-2" %>
+</div>
+
+
+  <div class="mb-4">
+    <%= f.label :address, "住所", class: "block font-bold" %>
+    <%= f.text_field :address, class: "form-input w-full border border-gray-300 rounded-md p-2" %>
+  </div>
+
+  <div class="mb-4">
+    <%= f.label :phone_number, "電話番号", class: "block font-bold" %>
+    <%= f.text_field :phone_number, class: "form-input w-full border border-gray-300 rounded-md p-2" %>
+  </div>
+
+  <div class="mb-4">
+    <%= f.label :hours, "営業時間", class: "block font-bold" %>
+    <%= f.text_field :hours, class: "form-input w-full border border-gray-300 rounded-md p-2" %>
+  </div>
+
+  <div class="mt-6">
+    <%= f.submit "登録する", class: "btn btn-primary bg-blue-500 text-white px-4 py-2 rounded-md" %>
+    <%= link_to "戻る", admin_stores_path, class: "btn btn-secondary ml-2 text-gray-700 underline" %>
+  </div>
+<% end %>
+

--- a/app/views/admin/stores/edit.html.erb
+++ b/app/views/admin/stores/edit.html.erb
@@ -1,0 +1,3 @@
+<h1>店舗情報を編集</h1>
+<%= render "form", store: @store %>
+<%= link_to "戻る", admin_stores_path, class: "btn btn-secondary" %>

--- a/app/views/admin/stores/index.html.erb
+++ b/app/views/admin/stores/index.html.erb
@@ -1,0 +1,28 @@
+<h1 class="text-2xl font-bold mb-4">店舗一覧</h1>
+
+<div class="mb-4">
+  <%= link_to '新規登録', new_admin_store_path, class: "bg-blue-500 text-white px-4 py-2 rounded hover:bg-blue-600" %>
+</div>
+
+<div class="space-y-4">
+  <% if @stores.present? %>
+    <% @stores.each do |store| %>
+      <div class="bg-white p-4 rounded-lg shadow-md flex justify-between items-center">
+        <div class="space-y-1">
+          <p><span class="font-bold">id:</span> <%= store.id %></p>
+          <p><span class="font-bold">店舗名:</span> <%= store.store_name %></p>
+          <p><span class="font-bold">カテゴリ:</span> <%= store.category_i18n %></p>
+          <p><span class="font-bold">住所:</span> <%= store.address %></p>
+          <p><span class="font-bold">電話番号:</span> <%= store.phone_number %></p>
+          <p><span class="font-bold">営業時間:</span> <%= store.hours %></p>
+        </div>
+        <div class="space-x-2">
+          <%= link_to '編集', edit_admin_store_path(store), class: "bg-yellow-500 text-white px-3 py-1 rounded hover:bg-yellow-600" %>
+          <%= link_to '削除', admin_store_path(store), data: { turbo_method: :delete, turbo_confirm: '本当に削除しますか？' }, class: "bg-red-500 text-white px-3 py-1 rounded hover:bg-red-600" %>
+        </div>
+      </div>
+    <% end %>
+  <% else %>
+    <p class="text-gray-600">登録された店舗がありません</p>
+  <% end %>
+</div>

--- a/app/views/admin/stores/new.html.erb
+++ b/app/views/admin/stores/new.html.erb
@@ -1,0 +1,3 @@
+<h1>新規店舗登録</h1>
+
+<%= render "form", store: @store %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -30,7 +30,7 @@
             <span style="margin-right: 10px;">こんにちは, <%= current_user.name || current_user.email %> さん</span>
 
             <%= form_with url: destroy_user_session_path, method: :delete, local: true, style: "display: inline;" do %>
-              <%= submit_tag "ログアウト", class: "btn btn-danger" %>
+              <%= submit_tag "ログアウト", class: "btn logout" %>
             <% end %>
           <% else %>
             <%= link_to "ログイン", new_user_session_path, class: "btn btn-primary" %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -39,6 +39,21 @@
       </nav>
     </header>
 
+    <%# アラートメッセージの表示 %>
+    <% if flash[:success] %>
+      <div class="bg-green-500"><%= flash[:success] %></div>
+    <% end %>
+    <% if flash[:error] %>
+      <div class="bg-yellow-500"><%= flash[:error] %></div>
+    <% end %>
+    <% if flash[:alert] %>
+      <div class="bg-red-500"><%= flash[:alert] %></div>
+    <% end %>
+    <% if flash[:notice] %>
+      <div class="bg-green-500"><%= flash[:notice] %></div>
+    <% end %>
+
+
     <main class="container">
       <%= yield %>
     </main>

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -47,7 +47,7 @@ Devise.setup do |config|
   # You can also supply a hash where the value is a boolean determining whether
   # or not authentication should be aborted when the value is not present.
   # ここ修正
-  config.authentication_keys = [:login]
+  config.authentication_keys = [ :login ]
 
 
   # Configure parameters from the request object used for authentication. Each entry

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -1,0 +1,10 @@
+ja:
+  activerecord:
+    attributes:
+      store:
+        categories:
+          Family_restaurant: "ファミレス"
+          Western_food: "洋食"
+          Japanese_food: "和食"
+          Chinese_food: "中華"
+          cafe: "カフェ"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,18 +2,23 @@ Rails.application.routes.draw do
   # トップページを表示（未ログインでもアクセス可能）
   root to: "home#index"
 
-  # Devise のルート（ユーザー登録カスタマイズ）
+  # Deviseのルート（ユーザー登録カスタマイズ）
   devise_for :users, controllers: {
-    registrations: 'users/registrations'
+    registrations: "users/registrations"
   }
 
-  # 店舗のルート（検索用）
-  resources :stores, only: [:index, :show]
+  # 店舗の検索
+  resources :stores, only: [ :index, :show ]
 
-  # ユーザー認証が必要な機能（お気に入り・レビューなど） → 後で実装
+  # 管理者用（店舗管理）
+  namespace :admin do
+    resources :stores
+  end
+
+  # ユーザー認証が必要な機能（お気に入り・レビューなど）
   authenticate :user do
-    resources :favorites, only: [:create, :destroy] # お気に入り機能（ログイン必須）
-    resources :reviews, only: [:create, :destroy]   # レビュー機能（ログイン必須）
+    resources :favorites, only: [ :create, :destroy ] # お気に入り機能（ログイン必須）
+    resources :reviews, only: [ :create, :destroy ]   # レビュー機能（ログイン必須）
   end
 
   # Rails のヘルスチェック用

--- a/db/migrate/20250212173347_devise_create_users.rb
+++ b/db/migrate/20250212173347_devise_create_users.rb
@@ -6,7 +6,7 @@ class DeviseCreateUsers < ActiveRecord::Migration[7.2]
       ## Database authenticatable
       t.string :email,              null: false, default: ""
       t.string :encrypted_password, null: false, default: ""
-      #ユーザー名追加
+      # ユーザー名追加
       t.string :name,               null: false, default: ""
 
       ## Recoverable

--- a/db/migrate/20250305151807_add_category_to_stores.rb
+++ b/db/migrate/20250305151807_add_category_to_stores.rb
@@ -1,0 +1,5 @@
+class AddCategoryToStores < ActiveRecord::Migration[7.2]
+  def change
+    add_column :stores, :category, :integer
+  end
+end

--- a/db/migrate/20250305171626_add_admin_to_users.rb
+++ b/db/migrate/20250305171626_add_admin_to_users.rb
@@ -1,0 +1,5 @@
+class AddAdminToUsers < ActiveRecord::Migration[7.2]
+  def change
+    add_column :users, :admin, :boolean
+  end
+end

--- a/db/migrate/20250306172825_add_name_to_stores.rb
+++ b/db/migrate/20250306172825_add_name_to_stores.rb
@@ -1,0 +1,5 @@
+class AddNameToStores < ActiveRecord::Migration[7.2]
+  def change
+    add_column :stores, :name, :string
+  end
+end

--- a/db/migrate/20250307193308_add_details_to_stores.rb
+++ b/db/migrate/20250307193308_add_details_to_stores.rb
@@ -1,0 +1,7 @@
+class AddDetailsToStores < ActiveRecord::Migration[7.2]
+  def change
+    add_column :stores, :address, :string
+    add_column :stores, :phone_number, :string
+    add_column :stores, :hours, :string
+  end
+end

--- a/db/migrate/20250308190347_add_image_url_to_stores.rb
+++ b/db/migrate/20250308190347_add_image_url_to_stores.rb
@@ -1,0 +1,5 @@
+class AddImageUrlToStores < ActiveRecord::Migration[7.2]
+  def change
+    add_column :stores, :image_url, :string
+  end
+end

--- a/db/migrate/20250308192205_add_genre_to_stores.rb
+++ b/db/migrate/20250308192205_add_genre_to_stores.rb
@@ -1,0 +1,5 @@
+class AddGenreToStores < ActiveRecord::Migration[7.2]
+  def change
+    add_column :stores, :genre, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_02_22_152147) do
+ActiveRecord::Schema[7.2].define(version: 2025_03_08_192205) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -18,6 +18,13 @@ ActiveRecord::Schema[7.2].define(version: 2025_02_22_152147) do
     t.string "store_name"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.integer "category"
+    t.string "name"
+    t.string "address"
+    t.string "phone_number"
+    t.string "hours"
+    t.string "image_url"
+    t.string "genre"
   end
 
   create_table "users", force: :cascade do |t|
@@ -32,6 +39,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_02_22_152147) do
     t.string "username"
     t.string "phone_number"
     t.string "name"
+    t.boolean "admin"
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end

--- a/test/controllers/admin/stores_controller_test.rb
+++ b/test/controllers/admin/stores_controller_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class Admin::StoresControllerTest < ActionDispatch::IntegrationTest
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
### ISSU番号
close #17 
close #18 
close #19 

### 概要
---
管理者ページを作成 (admin/stores)
管理者のみが admin/stores にアクセス可能（認可処理を追加）
管理者が店舗を新規登録・編集・削除できるように実装＋フラッシュメッセージを表示

### やったこと
---
✅ admin/stores ページを作成し、店舗一覧を表示
✅ admin/stores/new で新規登録フォームを実装
✅ admin/stores/:id/edit で 店舗の編集機能 を実装
✅ admin/stores/:id で 店舗の削除機能 を実装（削除時の確認ダイアログあり）
✅ Admin::StoresController に before_action :authorize_admin を追加し、管理者のみアクセス可能 に変更
✅ Store モデルに category を追加し、カテゴリー分類を実装
✅ ja.yml を作成し、管理画面の日本語化を設定
✅ 登録・編集・削除後に フラッシュメッセージ を表示

### できるようになること/できなくなること
---
👤 管理者:
・admin/stores にアクセスし、店舗一覧を確認できる
・店舗の新規登録・編集・削除ができる
・操作完了後にフラッシュメッセージが表示される

🚫 一般ユーザー:
adimin/storeにアクセスできなくなる

### 動作確認
---
✅ http://localhost:3000/admin/stores には管理者のみアクセス可能。店舗一覧が表示される
✅ http://localhost:3000/admin/stores/new で新規店舗登録ができる
✅ http://localhost:3000/admin/stores/:id/edit で 店舗の編集が反映される
✅ 削除ボタンを押すと、店舗情報が削除される
✅ 登録・編集・削除時にフラッシュメッセージが表示される

### 改善すること
---
