### PR TITLE
店舗情報のエリア追加＆店舗一覧に表示

### DIFF
--- a/app/controllers/admin/stores_controller.rb
+++ b/app/controllers/admin/stores_controller.rb
@@ -57,7 +57,7 @@ class Admin::StoresController < ApplicationController
 
     # ストリングパラメーター
     def store_params
-      params.require(:store).permit(:store_name, :category, :address, :phone_number, :hours)
+      params.require(:store).permit(:store_name, :category, :area, :address, :phone_number, :hours)
     end
 
     # 管理者のみアクセス許可

--- a/app/models/store.rb
+++ b/app/models/store.rb
@@ -1,12 +1,18 @@
 class Store < ApplicationRecord
     # 店のカテゴリー管理
     enum category: { Family_restaurant: 0, Western_food: 1, Japanese_food: 2, Chinese_food: 3, cafe: 4 }
-    # 必須情報
-    validates :store_name, presence: true
+    # エア管理
+    enum :area, { tokyo: 0, osaka: 1, nagoya: 2 }, prefix: true
+    # 必須情報（店名とエリア）
+    validates :store_name, :area, presence: true
 
     #カテゴリi18nの設定
     def category_i18n
         I18n.t("activerecord.attributes.store.categories.#{category}", locale: :ja)
     end
 
+    # エリアの日本語変換
+    def area_i18n
+    I18n.t("activerecord.attributes.store.areas.#{area}", locale: :ja)
+    end
 end

--- a/app/views/admin/stores/_form.html.erb
+++ b/app/views/admin/stores/_form.html.erb
@@ -4,10 +4,17 @@
     <%= f.text_field :store_name, class: "form-input w-full border border-gray-300 rounded-md p-2" %>
   </div>
 
+  <!--タグで選択-->
   <div class="mb-4">
   <%= f.label :category, "カテゴリー", class: "block font-bold" %>
   <%= f.select :category, Store.categories.keys.map { |c| [Store.new(category: c).category_i18n, c] }, {}, class: "form-select w-full border border-gray-300 rounded-md p-2" %>
-</div>
+  </div>
+
+  <!--タグで選択-->
+  <div class="mb-4">
+  <%= f.label :area, "エリア", class: "block font-bold" %>
+  <%= f.select :area, [["東京", "tokyo"], ["大阪", "osaka"], ["名古屋", "nagoya"]], {}, class: "form-select w-full border border-gray-300 rounded-md p-2" %>
+  </div>
 
 
   <div class="mb-4">
@@ -30,4 +37,3 @@
     <%= link_to "戻る", admin_stores_path, class: "btn btn-secondary ml-2 text-gray-700 underline" %>
   </div>
 <% end %>
-

--- a/app/views/admin/stores/index.html.erb
+++ b/app/views/admin/stores/index.html.erb
@@ -12,6 +12,7 @@
           <p><span class="font-bold">id:</span> <%= store.id %></p>
           <p><span class="font-bold">店舗名:</span> <%= store.store_name %></p>
           <p><span class="font-bold">カテゴリ:</span> <%= store.category_i18n %></p>
+          <p><span class="font-bold">エリア:</span> <%= store.area_i18n %></p>
           <p><span class="font-bold">住所:</span> <%= store.address %></p>
           <p><span class="font-bold">電話番号:</span> <%= store.phone_number %></p>
           <p><span class="font-bold">営業時間:</span> <%= store.hours %></p>

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -3,8 +3,12 @@ ja:
     attributes:
       store:
         categories:
-          Family_restaurant: "ファミレス"
+          Family_restaurant: "ファミリーレストラン"
           Western_food: "洋食"
           Japanese_food: "和食"
           Chinese_food: "中華"
           cafe: "カフェ"
+        areas:
+          tokyo: "東京"
+          osaka: "大阪"
+          nagoya: "名古屋"

--- a/db/migrate/20250311060128_add_area_to_stores.rb
+++ b/db/migrate/20250311060128_add_area_to_stores.rb
@@ -1,0 +1,5 @@
+class AddAreaToStores < ActiveRecord::Migration[7.2]
+  def change
+    add_column :stores, :area, :string
+  end
+end

--- a/db/migrate/20250311061916_change_area_type_to_stores.rb
+++ b/db/migrate/20250311061916_change_area_type_to_stores.rb
@@ -1,0 +1,6 @@
+#areaカラムをenumを使用するのでintegerの型にする
+class ChangeAreaTypeToStores < ActiveRecord::Migration[7.2]
+  def change
+    change_column :stores, :area, :integer, using: 'area::integer'
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_03_08_192205) do
+ActiveRecord::Schema[7.2].define(version: 2025_03_11_061916) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -25,6 +25,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_03_08_192205) do
     t.string "hours"
     t.string "image_url"
     t.string "genre"
+    t.integer "area"
   end
 
   create_table "users", force: :cascade do |t|


### PR DESCRIPTION
### 概要
---
これまで店舗情報には エリア（地域） の概念がありませんでした。
今回の実装により、店舗の新規登録時にエリアを選択でき、一覧画面でエリアを表示できるようになりました。

### 今回の実装で変化したこと
---
**追加前**
店舗情報に「エリア」の概念がなかった
登録フォームにエリアの入力項目がなかった
店舗一覧ページにエリア情報が表示されなかった

**追加後**
店舗情報に「エリア」を追加
店舗新規登録ページでエリアを選択できるようにした
店舗一覧ページにエリア情報を表示

### 🛠 やったこと
---
✅ stores テーブルに area カラムを追加（マイグレーション実施）
✅ Store モデルに enum :area を追加し、エリアを管理
✅ 管理画面（admin/stores）のフォームにエリアの選択項目を追加
✅ 店舗一覧画面（admin/stores/index）でエリアを表示
✅ config/locales/ja.yml にエリアの翻訳を追加し、日本語で表示できるようにした

### 🙅‍♂️ やらないこと
---
エリアの自由入力（現在は 東京・大阪・名古屋 のみ選択可能）

### 👀 できるようになること（ユーザー目線）
---
管理者が新規店舗登録時にエリアを選択できる
店舗一覧ページでエリアが表示され、どの地域の店舗かわかる
### 🚫 できなくなること（ユーザー目線）
---

なし
✅ 動作確認
✅ http://localhost:3000/admin/stores/new で店舗登録時にエリアを選択できることを確認
✅ http://localhost:3000/admin/stores でエリアが正しく表示されることを確認
✅ エリアの翻訳（東京・大阪・名古屋）が config/locales/ja.yml の設定通り表示されることを確認

### 📝 その他
---
なし
