### PR TITLE
子連れ向け情報を追加

### DIFF
--- a/app/models/store.rb
+++ b/app/models/store.rb
@@ -1,18 +1,63 @@
 class Store < ApplicationRecord
-    # 店のカテゴリー管理
-    enum category: { Family_restaurant: 0, Western_food: 1, Japanese_food: 2, Chinese_food: 3, cafe: 4 }
-    # エア管理
-    enum :area, { tokyo: 0, osaka: 1, nagoya: 2 }, prefix: true
-    # 必須情報（店名とエリア）
-    validates :store_name, :area, presence: true
+  # 店のカテゴリー管理
+  enum :category, { Family_restaurant: 0, Western_food: 1, Japanese_food: 2, Chinese_food: 3, cafe: 4 }
 
-    #カテゴリi18nの設定
-    def category_i18n
-        I18n.t("activerecord.attributes.store.categories.#{category}", locale: :ja)
-    end
+  # エリア管理
+  enum :area, { tokyo: 0, osaka: 1, nagoya: 2 }, prefix: true
 
-    # エリアの日本語変換
-    def area_i18n
+  # 子連れ向け情報（デフォルトを設定）
+  enum :private_room, { unknown: 0, available: 1, not_available: 2 }, prefix: true, default: :unknown
+  enum :tatami, { unknown: 0, available: 1, not_available: 2 }, prefix: true, default: :unknown
+  enum :kids_chair, { unknown: 0, available: 1, not_available: 2 }, prefix: true, default: :unknown
+  enum :stroller, { unknown: 0, available: 1, not_available: 2 }, prefix: true, default: :unknown
+  enum :allergy_menu, { unknown: 0, available: 1, not_available: 2 }, prefix: true, default: :unknown
+  enum :kids_space, { unknown: 0, available: 1, not_available: 2 }, prefix: true, default: :unknown
+  enum :diaper_changing, { unknown: 0, available: 1, not_available: 2 }, prefix: true, default: :unknown
+  enum :nursing_room, { unknown: 0, available: 1, not_available: 2 }, prefix: true, default: :unknown
+
+  # 必須情報（店名とエリア）
+  validates :store_name, :area, presence: true
+
+  # カテゴリー i18n
+  def category_i18n
+    I18n.t("activerecord.attributes.store.categories.#{category}", locale: :ja)
+  end
+
+  # エリア i18n
+  def area_i18n
     I18n.t("activerecord.attributes.store.areas.#{area}", locale: :ja)
-    end
+  end
+
+  # 子連れ向け情報の i18n
+  def private_room_i18n
+    I18n.t("activerecord.attributes.store.kids_friendly.private_room.#{private_room || 'unknown'}", locale: :ja)
+  end
+
+  def tatami_i18n
+    I18n.t("activerecord.attributes.store.kids_friendly.tatami.#{tatami || 'unknown'}", locale: :ja)
+  end
+
+  def kids_chair_i18n
+    I18n.t("activerecord.attributes.store.kids_friendly.kids_chair.#{kids_chair || 'unknown'}", locale: :ja)
+  end
+
+  def stroller_i18n
+    I18n.t("activerecord.attributes.store.kids_friendly.stroller.#{stroller || 'unknown'}", locale: :ja)
+  end
+
+  def allergy_menu_i18n
+    I18n.t("activerecord.attributes.store.kids_friendly.allergy_menu.#{allergy_menu || 'unknown'}", locale: :ja)
+  end
+
+  def kids_space_i18n
+    I18n.t("activerecord.attributes.store.kids_friendly.kids_space.#{kids_space || 'unknown'}", locale: :ja)
+  end
+
+  def diaper_changing_i18n
+    I18n.t("activerecord.attributes.store.kids_friendly.diaper_changing.#{diaper_changing || 'unknown'}", locale: :ja)
+  end
+
+  def nursing_room_i18n
+    I18n.t("activerecord.attributes.store.kids_friendly.nursing_room.#{nursing_room || 'unknown'}", locale: :ja)
+  end
 end

--- a/app/views/admin/stores/_form.html.erb
+++ b/app/views/admin/stores/_form.html.erb
@@ -32,6 +32,120 @@
     <%= f.text_field :hours, class: "form-input w-full border border-gray-300 rounded-md p-2" %>
   </div>
 
+  <!--子連れ向け情報-->
+  <div class="mb-4">
+  <label class="block font-bold">個室</label>
+  <div class="flex space-x-4">
+    <%= f.radio_button :private_room, "available", id: "private_room_available", class: "form-radio" %>
+    <%= f.label :private_room_available, "あり", for: "private_room_available", class: "ml-1" %>
+
+    <%= f.radio_button :private_room, "not_available", id: "private_room_not_available", class: "form-radio" %>
+    <%= f.label :private_room_not_available, "なし", for: "private_room_not_available", class: "ml-1" %>
+
+    <%= f.radio_button :private_room, "unknown", id: "private_room_unknown", class: "form-radio" %>
+    <%= f.label :private_room_unknown, "不明", for: "private_room_unknown", class: "ml-1" %>
+  </div>
+</div>
+
+  <div class="mb-4">
+  <label class="block font-bold">座敷</label>
+  <div class="flex space-x-4">
+    <%= f.radio_button :tatami, "available", id: "tatami_available", class: "form-radio" %>
+    <%= f.label :tatami_available, "あり", for: "tatami_available", class: "ml-1" %>
+
+    <%= f.radio_button :tatami, "not_available", id: "tatami_not_available", class: "form-radio" %>
+    <%= f.label :tatami_not_available, "なし", for: "tatami_not_available", class: "ml-1" %>
+
+    <%= f.radio_button :tatami, "unknown", id: "tatami_unknown", class: "form-radio" %>
+    <%= f.label :tatami_unknown, "不明", for: "tatami_unknown", class: "ml-1" %>
+  </div>
+</div>
+
+  <div class="mb-4">
+  <label class="block font-bold">子供用椅子</label>
+  <div class="flex space-x-4">
+    <%= f.radio_button :kids_chair, "available", id: "kids_chair_available", class: "form-radio" %>
+    <%= f.label :kids_chair_available, "あり", for: "kids_chair_available", class: "ml-1" %>
+
+    <%= f.radio_button :kids_chair, "not_available", id: "kids_chair_not_available", class: "form-radio" %>
+    <%= f.label :kids_chair_not_available, "なし", for: "kids_chair_not_available", class: "ml-1" %>
+
+    <%= f.radio_button :kids_chair, "unknown", id: "kids_chair_unknown", class: "form-radio" %>
+    <%= f.label :kids_chair_unknown, "不明", for: "kids_chair_unknown", class: "ml-1" %>
+  </div>
+</div>
+
+    <div class="mb-4">
+    <label class="block font-bold">ベビーカー入店可</label>
+    <div class="flex space-x-4">
+        <%= f.radio_button :stroller, "available", id: "stroller_available", class: "form-radio" %>
+        <%= f.label :stroller_available, "可能", for: "stroller_available", class: "ml-1" %>
+
+        <%= f.radio_button :stroller, "not_available", id: "stroller_not_available", class: "form-radio" %>
+        <%= f.label :stroller_not_available, "不可", for: "stroller_not_available", class: "ml-1" %>
+
+        <%= f.radio_button :stroller, "unknown", id: "stroller_unknown", class: "form-radio" %>
+        <%= f.label :stroller_unknown, "不明", for: "stroller_unknown", class: "ml-1" %>
+    </div>
+    </div>
+
+    <div class="mb-4">
+    <label class="block font-bold">アレルギー対応メニュー</label>
+    <div class="flex space-x-4">
+        <%= f.radio_button :allergy_menu, "available", id: "allergy_menu_available", class: "form-radio" %>
+        <%= f.label :allergy_menu_available, "あり", for: "allergy_menu_available", class: "ml-1" %>
+
+        <%= f.radio_button :allergy_menu, "not_available", id: "allergy_menu_not_available", class: "form-radio" %>
+        <%= f.label :allergy_menu_not_available, "なし", for: "allergy_menu_not_available", class: "ml-1" %>
+
+        <%= f.radio_button :allergy_menu, "unknown", id: "allergy_menu_unknown", class: "form-radio" %>
+        <%= f.label :allergy_menu_unknown, "不明", for: "allergy_menu_unknown", class: "ml-1" %>
+    </div>
+    </div>
+
+    <div class="mb-4">
+    <label class="block font-bold">キッズスペース</label>
+    <div class="flex space-x-4">
+        <%= f.radio_button :kids_space, "available", id: "kids_space_available", class: "form-radio" %>
+        <%= f.label :kids_space_available, "あり", for: "kids_space_available", class: "ml-1" %>
+
+        <%= f.radio_button :kids_space, "not_available", id: "kids_space_not_available", class: "form-radio" %>
+        <%= f.label :kids_space_not_available, "なし", for: "kids_space_not_available", class: "ml-1" %>
+
+        <%= f.radio_button :kids_space, "unknown", id: "kids_space_unknown", class: "form-radio" %>
+        <%= f.label :kids_space_unknown, "不明", for: "kids_space_unknown", class: "ml-1" %>
+    </div>
+    </div>
+
+    <div class="mb-4">
+    <label class="block font-bold">おむつ交換台</label>
+    <div class="flex space-x-4">
+        <%= f.radio_button :diaper_changing, "available", id: "diaper_changing_available", class: "form-radio" %>
+        <%= f.label :diaper_changing_available, "あり", for: "diaper_changing_available", class: "ml-1" %>
+
+        <%= f.radio_button :diaper_changing, "not_available", id: "diaper_changing_not_available", class: "form-radio" %>
+        <%= f.label :diaper_changing_not_available, "なし", for: "diaper_changing_not_available", class: "ml-1" %>
+
+        <%= f.radio_button :diaper_changing, "unknown", id: "diaper_changing_unknown", class: "form-radio" %>
+        <%= f.label :diaper_changing_unknown, "不明", for: "diaper_changing_unknown", class: "ml-1" %>
+    </div>
+    </div>
+
+    <div class="mb-4">
+    <label class="block font-bold">授乳室</label>
+    <div class="flex space-x-4">
+        <%= f.radio_button :nursing_room, "available", id: "nursing_room_available", class: "form-radio" %>
+        <%= f.label :nursing_room_available, "あり", for: "nursing_room_available", class: "ml-1" %>
+
+        <%= f.radio_button :nursing_room, "not_available", id: "nursing_room_not_available", class: "form-radio" %>
+        <%= f.label :nursing_room_not_available, "なし", for: "nursing_room_not_available", class: "ml-1" %>
+
+        <%= f.radio_button :nursing_room, "unknown", id: "nursing_room_unknown", class: "form-radio" %>
+        <%= f.label :nursing_room_unknown, "不明", for: "nursing_room_unknown", class: "ml-1" %>
+    </div>
+    </div>
+
+
   <div class="mt-6">
     <%= f.submit "登録する", class: "btn btn-primary bg-blue-500 text-white px-4 py-2 rounded-md" %>
     <%= link_to "戻る", admin_stores_path, class: "btn btn-secondary ml-2 text-gray-700 underline" %>

--- a/app/views/admin/stores/index.html.erb
+++ b/app/views/admin/stores/index.html.erb
@@ -16,6 +16,15 @@
           <p><span class="font-bold">住所:</span> <%= store.address %></p>
           <p><span class="font-bold">電話番号:</span> <%= store.phone_number %></p>
           <p><span class="font-bold">営業時間:</span> <%= store.hours %></p>
+          <p><span class="font-bold">個室:</span> <%= store.private_room_i18n %></p>
+          <p><span class="font-bold">座敷:</span> <%= store.tatami_i18n %></p>
+          <p><span class="font-bold">子供用椅子:</span> <%= store.kids_chair_i18n %></p>
+          <p><span class="font-bold">ベビーカー入店:</span> <%= store.stroller_i18n %></p>
+          <p><span class="font-bold">アレルギー対応メニュー:</span> <%= store.allergy_menu_i18n %></p>
+          <p><span class="font-bold">キッズスペース:</span> <%= store.kids_space_i18n %></p>
+          <p><span class="font-bold">おむつ交換台:</span> <%= store.diaper_changing_i18n %></p>
+          <p><span class="font-bold">授乳室:</span> <%= store.nursing_room_i18n %></p>
+
         </div>
         <div class="space-x-2">
           <%= link_to '編集', edit_admin_store_path(store), class: "bg-yellow-500 text-white px-3 py-1 rounded hover:bg-yellow-600" %>

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -12,3 +12,36 @@ ja:
           tokyo: "東京"
           osaka: "大阪"
           nagoya: "名古屋"
+        kids_friendly:
+          private_room:
+            available: "あり"
+            not_available: "なし"
+            unknown: "不明"
+          tatami:
+            available: "あり"
+            not_available: "なし"
+            unknown: "不明"
+          kids_chair:
+            available: "あり"
+            not_available: "なし"
+            unknown: "不明"
+          stroller:
+            available: "可能"
+            not_available: "不可"
+            unknown: "不明"
+          allergy_menu:
+            available: "あり"
+            not_available: "なし"
+            unknown: "不明"
+          kids_space:
+            available: "あり"
+            not_available: "なし"
+            unknown: "不明"
+          diaper_changing:
+            available: "あり（施設内）"
+            not_available: "なし"
+            unknown: "不明"
+          nursing_room:
+            available: "あり（施設内）"
+            not_available: "なし"
+            unknown: "不明"

--- a/db/migrate/20250311151429_add_child_friendly_features_to_stores.rb
+++ b/db/migrate/20250311151429_add_child_friendly_features_to_stores.rb
@@ -1,0 +1,12 @@
+class AddChildFriendlyFeaturesToStores < ActiveRecord::Migration[7.2]
+  def change
+    add_column :stores, :private_room, :integer
+    add_column :stores, :tatami, :integer
+    add_column :stores, :kids_chair, :integer
+    add_column :stores, :stroller, :integer
+    add_column :stores, :allergy_menu, :integer
+    add_column :stores, :kids_space, :integer
+    add_column :stores, :diaper_changing, :integer
+    add_column :stores, :nursing_room, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_03_11_061916) do
+ActiveRecord::Schema[7.2].define(version: 2025_03_11_151429) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -26,6 +26,14 @@ ActiveRecord::Schema[7.2].define(version: 2025_03_11_061916) do
     t.string "image_url"
     t.string "genre"
     t.integer "area"
+    t.integer "private_room"
+    t.integer "tatami"
+    t.integer "kids_chair"
+    t.integer "stroller"
+    t.integer "allergy_menu"
+    t.integer "kids_space"
+    t.integer "diaper_changing"
+    t.integer "nursing_room"
   end
 
   create_table "users", force: :cascade do |t|


### PR DESCRIPTION
### 概要
---
店舗情報に 子連れ向けの設備・サービス情報 を追加しました。
これにより、管理者は子連れに優しい店舗かどうかを登録でき、ユーザーが検索しやすくなります。


### 追加した項目
---
✅ 個室（あり / なし / 不明）
✅ 座敷（あり / なし / 不明）
✅ 子供用椅子（あり / なし / 不明）
✅ ベビーカー入店可（可能 / 不可 / 不明）
✅ アレルギー対応メニュー（あり / なし / 不明）
✅ キッズスペース（あり / なし / 不明）
✅ おむつ交換台（あり（施設内）/ なし / 不明）
✅ 授乳室（あり（施設内）/ なし / 不明）

### やったこと
---
✅ Store モデルに 子連れ向け情報の enum を追加
✅ config/locales/ja.yml に 子連れ向け情報の日本語翻訳を追加
✅ 管理者ページ (admin/stores/new) で子連れ向け情報を入力できるように変更
✅ 店舗一覧 (admin/stores/index) に登録した子連れ情報を表示

### やらないこと
---
🚫 なし

### できるようになること
**👤 管理者**
店舗登録時に「子連れ向け情報」を入力できる
登録済みの店舗の「子連れ向け情報」を編集・更新できる
店舗一覧で「子連れ向け情報」を確認できる

**🤱ユーザー**
なし

### できなくなること
---
なし

動作確認
✅ /admin/stores/new で 子連れ向け情報の登録ができる
✅ /admin/stores/:id/edit で 登録した情報を編集できる
✅ /admin/stores で 店舗の子連れ向け情報が表示される

### その他
---
現状、店舗一覧で全情報が表示されているため、見やすくするUI改善が必要
次のタスクで「子連れ向け情報での検索機能」を実装予定