### PR TITLE
店舗一覧ページの改良 & 編集機能の改善

### DIFF
--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -1,3 +1,5 @@
 // Entry point for the build script in your package.json
 import "@hotwired/turbo-rails"
 import "./controllers"
+//toggleDetails.js を読み込む
+import "./toggleDetails";

--- a/app/javascript/toggleDetails.js
+++ b/app/javascript/toggleDetails.js
@@ -1,0 +1,23 @@
+//ページが完全に読み込まれた後にスクリプトを実行
+document.addEventListener("DOMContentLoaded", () => {
+  console.log("toggleDetails.js is loaded!");  // デバッグ用ログ
+
+  //.toggle-details クラスを持つ全ての <a> 要素に click イベントを設定
+  document.querySelectorAll(".toggle-details").forEach((element) => {
+    element.addEventListener("click", (event) => {
+      event.preventDefault();
+      //id="details-STORE_IDのdivを取得して、クリックされた店舗の詳細情報を表示、非表示の切り替え
+      let storeId = event.target.dataset.storeId;
+      let detailsDiv = document.getElementById(`details-${storeId}`);
+
+      console.log(`toggleDetails called for storeId: ${storeId}`); // デバッグ用ログ
+
+      //display:none;とisplay:blockの切り替え
+      if (detailsDiv.style.display === "none" || detailsDiv.style.display === "") {
+        detailsDiv.style.display = "block";
+      } else {
+        detailsDiv.style.display = "none";
+      }
+    });
+  });
+});

--- a/app/views/admin/stores/_form.html.erb
+++ b/app/views/admin/stores/_form.html.erb
@@ -147,7 +147,7 @@
 
 
   <div class="mt-6">
-    <%= f.submit "登録する", class: "btn btn-primary bg-blue-500 text-white px-4 py-2 rounded-md" %>
+    <%= f.submit @store.new_record? ? "登録する" : "更新", class: "btn btn-primary bg-blue-500 text-white px-4 py-2 rounded-md" %>
     <%= link_to "戻る", admin_stores_path, class: "btn btn-secondary ml-2 text-gray-700 underline" %>
   </div>
 <% end %>

--- a/app/views/admin/stores/edit.html.erb
+++ b/app/views/admin/stores/edit.html.erb
@@ -1,3 +1,2 @@
 <h1>店舗情報を編集</h1>
 <%= render "form", store: @store %>
-<%= link_to "戻る", admin_stores_path, class: "btn btn-secondary" %>

--- a/app/views/admin/stores/index.html.erb
+++ b/app/views/admin/stores/index.html.erb
@@ -7,10 +7,15 @@
 <div class="space-y-4">
   <% if @stores.present? %>
     <% @stores.each do |store| %>
-      <div class="bg-white p-4 rounded-lg shadow-md flex justify-between items-center">
-        <div class="space-y-1">
-          <p><span class="font-bold">id:</span> <%= store.id %></p>
-          <p><span class="font-bold">店舗名:</span> <%= store.store_name %></p>
+      <div class="bg-white p-4 rounded-lg shadow-md">
+        <p>
+          <!--店舗名をクリックしたら詳細が出てくるイベント設定-->
+          <a href="#" class="toggle-details font-bold text-blue-500" data-store-id="<%= store.id %>">
+            <%= store.store_name %>
+          </a>
+        </p>
+        
+        <div id="details-<%= store.id %>" style="display: none;" class="mt-2 p-2 border border-gray-300 rounded-lg bg-gray-100">
           <p><span class="font-bold">カテゴリ:</span> <%= store.category_i18n %></p>
           <p><span class="font-bold">エリア:</span> <%= store.area_i18n %></p>
           <p><span class="font-bold">住所:</span> <%= store.address %></p>
@@ -25,10 +30,11 @@
           <p><span class="font-bold">おむつ交換台:</span> <%= store.diaper_changing_i18n %></p>
           <p><span class="font-bold">授乳室:</span> <%= store.nursing_room_i18n %></p>
 
-        </div>
-        <div class="space-x-2">
-          <%= link_to '編集', edit_admin_store_path(store), class: "bg-yellow-500 text-white px-3 py-1 rounded hover:bg-yellow-600" %>
-          <%= link_to '削除', admin_store_path(store), data: { turbo_method: :delete, turbo_confirm: '本当に削除しますか？' }, class: "bg-red-500 text-white px-3 py-1 rounded hover:bg-red-600" %>
+          <!-- 編集・削除ボタン -->
+          <div class="mt-3 space-x-2">
+            <%= link_to '編集', edit_admin_store_path(store), class: "bg-yellow-500 text-white px-3 py-1 rounded hover:bg-yellow-600" %>
+            <%= link_to '削除', admin_store_path(store), data: { turbo_method: :delete, turbo_confirm: '本当に削除しますか？' }, class: "bg-red-500 text-white px-3 py-1 rounded hover:bg-red-600" %>
+          </div>
         </div>
       </div>
     <% end %>


### PR DESCRIPTION
### 概要
---
店舗情報が増えたことで一覧ページが見づらくなってしまったため
デフォルトでは店舗名のみを表示し、クリックすると詳細情報や編集・削除ボタンが展開されるように変更しました。
また、店舗編集ページの戻るボタンの重複を解消し、登録ボタンの文言を適切に変更しました。

### 🛠 やったこと
---
✅ 店舗一覧ページ (index.html.erb) の改善
店舗名をクリックすると詳細情報（カテゴリ・エリア・設備など）が展開される仕様を追加
編集・削除ボタンも詳細情報と一緒に表示されるように変更
デフォルトでは店舗名とIDのみを表示し、クリックで他の情報を見れるように調整

✅ JavaScript (toggleDetails.js) の実装
クリック時に詳細情報を表示・非表示できるスクリプトを作成
JSファイルを application.js で正しく読み込むよう修正
console.log() を用いたデバッグで、イベントが正しく発火するか確認

✅ 店舗編集ページ (edit.html.erb) の修正
「戻る」ボタンが2つあったため、1つに統一
フォームの「登録する」ボタンを、編集時は「更新」と表示されるように修正

### 🙋‍♂️ できるようになること
---
**👤 管理者**
店舗一覧ページがスッキリし、店舗名をクリックすると詳細が見れる
（編集・削除ボタンも、詳細と一緒に表示される）
店舗情報を編集した際に登録ボタンを押す仕様から、更新ボタンに変更

### 動作確認
---
✅ 店舗名をクリックすると、詳細情報が展開される
✅ 編集・削除ボタンも詳細表示と一緒に表示される
✅ 編集ページで戻るボタンが1つだけ表示される
✅ 新規登録時 → ボタンが「登録する」、編集時 → ボタンが「更新」となることを確認

###  その他
---