### PR TITLE
Search

### DIFF
--- a/app/models/store.rb
+++ b/app/models/store.rb
@@ -13,6 +13,15 @@ class Store < ApplicationRecord
 
     #エリアのi18n
     def area_i18n
-        I18n.t("activerecord.attributes.store.areas.#{area}", locale: :ja, default: "未設定")
+    I18n.t("activerecord.attributes.store.areas.#{area}", locale: :ja)
+    end
+
+    #子連れ情報i18n
+    def self.kids_friendly_i18n(attr)
+    I18n.t("activerecord.attributes.store.kids_friendly.#{attr}", locale: :ja)
+    end
+
+    def self.kids_friendly_attributes
+    %w[private_room tatami kids_chair stroller allergy_menu kids_space diaper_changing nursing_room]
     end
 end

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -10,19 +10,31 @@
     <%= form_with url: search_stores_path, method: :get, local: true, data: { turbo: false } do |f| %>
       <div class="search-options">
         <div>
-          <%= f.label :area, "エリア" %>
-          <%= f.select :area, Store.areas.keys.map { |a| [I18n.t("activerecord.attributes.store.areas.#{a}", default: a), a] }, { include_blank: "すべて" }, class: "form-select" %>
+          <div class="search-options">
+          <div>
+            <%= f.label :area, "エリア" %>
+            <%= f.select :area, Store.areas.keys.map { |a| [Store.new(area: a).area_i18n, a] }, { include_blank: "すべて" }, class: "form-select" %>
+          </div>
+
+          <div>
+            <%= f.label :category, "ジャンル" %>
+            <%= f.select :category, Store.categories.keys.map { |c| [Store.new(category: c).category_i18n, c] }, { include_blank: "すべて" }, class: "form-select" %>
+          </div>
         </div>
 
+        <!-- ✅ 子連れ情報のチェックボックス -->
         <div>
-          <%= f.label :category, "ジャンル" %>
-          <%= f.select :category, Store.categories.keys.map { |c| [Store.new(category: c).category_i18n, c] }, { include_blank: "すべて" }, class: "form-select" %>
+          <p>子連れ対応設備</p>
+          <% Store.kids_friendly_attributes.each do |attr| %>
+            <div>
+              <%= f.check_box "kids_friendly[#{attr}]", {}, "available", nil %>
+              <%= label_tag "kids_friendly_#{attr}", Store.kids_friendly_i18n(attr) %>
+            </div>
+          <% end %>
         </div>
-      </div>
-
-      <%= f.submit "検索", class: "btn btn-primary" %>
-    <% end %>
-  </div>
+              <%= f.submit "検索", class: "btn btn-primary" %>
+            <% end %>
+          </div>
 
   <!-- 店舗リスト -->
   <div class="store-list">

--- a/config/application.rb
+++ b/config/application.rb
@@ -16,6 +16,9 @@ module Myapp
     # Common ones are `templates`, `generators`, or `middleware`, for example.
     config.autoload_lib(ignore: %w[assets tasks])
 
+    # ✅ 日本語をデフォルトの言語に設定
+    config.i18n.default_locale = :ja
+
     # Configuration for the application, engines, and railties goes here.
     #
     # These settings can be overridden in specific environments using the files

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -12,3 +12,12 @@ ja:
           Japanese_food: "和食"
           Chinese_food: "中華"
           cafe: "カフェ"
+        kids_friendly:
+          private_room: "個室"
+          tatami: "座敷"
+          kids_chair: "キッズチェア"
+          stroller: "ベビーカー入店可"
+          allergy_menu: "アレルギー対応メニュー"
+          kids_space: "キッズスペース"
+          diaper_changing: "おむつ交換台"
+          nursing_room: "授乳室"


### PR DESCRIPTION
### 📌 概要
---
エリア・ジャンル・子連れ対応設備での 絞り込み検索機能 を実装しました。

過去の実装ではエリア・ジャンルの検索のみが可能でしたが、
今回の修正で子連れ対応設備（個室・座敷・キッズチェアなど）でも検索できるようになりました。

### 🛠 やったこと
---
✅ 検索機能の実装
エリア・ジャンル・子連れ対応設備での AND 検索 に対応
子連れ対応設備の検索時に enum の値（整数）で検索できるよう修正
where の検索条件を Hash にまとめ、可読性を向上
✅ エラー修正
PG::InvalidTextRepresentation エラーの解消
子連れ情報の検索時、boolean ではなく enum の integer 値を利用

### 🙋‍♂️ できるようになること
---
### 👤 ユーザー
「エリア」「ジャンル」「子連れ対応設備」の 条件を組み合わせて検索 できる
エラーなく 検索機能を利用できる

### 👤 管理者
子連れ対応設備のフィルタリングが可能
ユーザー向け検索時のパフォーマンスが向上

### ✅ 動作確認
🔍 検索ページ (search.html.erb)

 エリア・ジャンルのみで検索ができる
 子連れ対応設備（個室・座敷など）を選択し、検索結果が正しく反映される
 複数の条件を組み合わせた検索が動作する（例: 東京 × 和食 × キッズチェアあり）

### 📌 備考
---
検索結果に ページネーション機能（kaminari など）を追加することを検討
