### PR TITLE
トップページのエラー（日本語化）解消

### DIFF
--- a/app/models/store.rb
+++ b/app/models/store.rb
@@ -60,4 +60,14 @@ class Store < ApplicationRecord
   def nursing_room_i18n
     I18n.t("activerecord.attributes.store.kids_friendly.nursing_room.#{nursing_room}", locale: :ja)
   end
+
+  # ✅ 子連れ向け情報の属性一覧を取得
+  def self.kids_friendly_attributes
+    %w[private_room tatami kids_chair stroller allergy_menu kids_space diaper_changing nursing_room]
+  end
+
+  # ✅ 子連れ向け情報の i18n ラベルを取得
+  def self.kids_friendly_i18n(attr)
+  I18n.t("activerecord.attributes.store.kids_friendly_labels.#{attr}", locale: :ja)
+  end
 end

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -45,3 +45,12 @@ ja:
             available: "あり（施設内）"
             not_available: "なし"
             unknown: "不明"
+        kids_friendly_labels:
+          private_room: "個室"
+          tatami: "座敷"
+          kids_chair: "キッズチェア"
+          stroller: "ベビーカー入店可"
+          allergy_menu: "アレルギー対応メニュー"
+          kids_space: "キッズスペース"
+          diaper_changing: "おむつ交換台"
+          nursing_room: "授乳室"


### PR DESCRIPTION
子連れ向け絞り込み用チェック項目のi18nが適用できていなかった為
修正を行いました。