### PR TITLE
ログイン時のバリデーションエラーの修正

### DIFF
--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -1,61 +1,48 @@
 # frozen_string_literal: true
 
 class Users::RegistrationsController < Devise::RegistrationsController
-  before_action :configure_sign_up_params, only: [ :create ]
-  before_action :configure_account_update_params, only: [ :update ]
-
-  # GET /resource/sign_up
-  # def new
-  #   super
-  # end
+  before_action :configure_sign_up_params, only: [:create]
+  before_action :configure_account_update_params, only: [:update]
 
   # POST /resource
-  # def create
-  #   super
-  # end
+  def create
+    build_resource(sign_up_params)
 
-  # GET /resource/edit
-  # def edit
-  #   super
-  # end
-
-  # PUT /resource
-  # def update
-  #   super
-  # end
-
-  # DELETE /resource
-  # def destroy
-  #   super
-  # end
-
-  # GET /resource/cancel
-  # Forces the session data which is usually expired after sign
-  # in to be expired now. This is useful if the user wants to
-  # cancel oauth signing in/up in the middle of the process,
-  # removing all OAuth session data.
-  # def cancel
-  #   super
-  # end
+    resource.save
+    yield resource if block_given?
+    if resource.persisted?
+      if resource.active_for_authentication?
+        set_flash_message! :notice, :signed_up
+        sign_up(resource_name, resource)
+        respond_with resource, location: after_sign_up_path_for(resource)
+      else
+        set_flash_message! :notice, :"signed_up_but_#{resource.inactive_message}"
+        expire_data_after_sign_in!
+        respond_with resource, location: after_inactive_sign_up_path_for(resource)
+      end
+    else
+      clean_up_passwords resource
+      set_minimum_password_length
+      # エラー時にステータスコードを付与！
+      respond_with resource, status: :unprocessable_entity
+    end
+  end
 
   protected
 
-  # If you have extra params to permit, append them to the sanitizer.
   def configure_sign_up_params
-    devise_parameter_sanitizer.permit(:sign_up, keys: [ :name ])
+    devise_parameter_sanitizer.permit(:sign_up, keys: [:name])
   end
 
-  # If you have extra params to permit, append them to the sanitizer.
   def configure_account_update_params
-    devise_parameter_sanitizer.permit(:account_update, keys: [ :name ])
+    devise_parameter_sanitizer.permit(:account_update, keys: [:name])
   end
 
-  # The path used after sign up.新規登録後の遷移先
+  # 新規登録後の遷移先
   def after_sign_up_path_for(resource)
     root_path
   end
 
-  # The path used after sign up for inactive accounts.
   def after_inactive_sign_up_path_for(resource)
     posts_path
   end

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -1,5 +1,16 @@
 <h2>新規登録</h2>
 
+<% if resource.errors.any? %>
+  <div id="error_explanation" class="bg-red-500 text-white p-4 rounded mb-4">
+    <h2><%= pluralize(resource.errors.count, "件のエラー") %>が発生しました：</h2>
+    <ul class="list-disc pl-5">
+      <% resource.errors.full_messages.each do |message| %>
+        <li><%= message %></li>
+      <% end %>
+    </ul>
+  </div>
+<% end %>
+
 <%= form_with model: resource, url: registration_path(resource_name), local: true do |f| %>
   <!--ユーザー名追加-->
   <div class="field">

--- a/config/locales/devise.ja.yml
+++ b/config/locales/devise.ja.yml
@@ -1,0 +1,40 @@
+ja:
+  errors:
+    messages:
+      not_saved:
+        one:   "エラーが1件発生したため %{resource} は保存されませんでした。"
+        other: "%{count} 件のエラーが発生したため %{resource} は保存されませんでした。"
+
+  activerecord:
+    models:
+      user:
+        one: "ユーザー"
+        other: "ユーザー"
+    errors:
+      models:
+        user:
+          attributes:
+            email:
+              blank: "を入力してください"
+              taken: "はすでに使用されています"
+            password:
+              too_short: "は%{count}文字以上にしてください"
+              confirmation: "が確認用と一致しません"
+
+  devise:
+    sessions:
+      new:
+        sign_in: "ログイン"
+
+    registrations:
+      new:
+        sign_up: "アカウント登録"
+      edit:
+        edit: "登録情報編集"
+        cancel_my_account: "アカウントを削除する"
+
+    shared:
+      links:
+        sign_up: "アカウント登録"
+        sign_in: "ログイン"
+        forgot_your_password: "パスワードを忘れましたか？"


### PR DESCRIPTION
### 📌 概要
--- 
ユーザー新規登録時のバリデーションエラーが画面上に表示されない不具合を修正。
また、エラーメッセージがわかり易いようにスタイルを追加。

### 🔧 変更内容
--- 
app/views/devise/registrations/new.html.erb に error_explanation を追加
エラー表示に Tailwind CSS クラスを使用し、背景色・文字色を設定
config/locales/ja.yml に activerecord.models.user.one / other を追加し、エラー表示時の translation missing を解消

### ✅ 動作確認
--- 
パスワードが短い、または確認用と一致しない状態で登録ボタンを押すと
入力欄の上に赤背景でエラーメッセージが表示されることを確認

### 📝 補足
---
devise の I18n の翻訳漏れ（user.one がない）によるエラーも合わせて修正