### PR TITLE
店舗詳細ページとレビュー機能の実装

### DIFF
--- a/app/controllers/reviews_controller.rb
+++ b/app/controllers/reviews_controller.rb
@@ -1,0 +1,26 @@
+class ReviewsController < ApplicationController
+  before_action :authenticate_user!
+
+  def new
+    @store = Store.find(params[:store_id])
+    @review = @store.reviews.build
+  end
+
+  def create
+    @store = Store.find(params[:store_id])
+    @review = @store.reviews.build(review_params)
+    @review.user = current_user
+
+    if @review.save
+      redirect_to store_path(@store), notice: 'レビューを投稿しました。'
+    else
+      render :new, status: :unprocessable_entity
+    end
+  end
+
+  private
+
+  def review_params
+    params.require(:review).permit(:content)
+  end
+end

--- a/app/controllers/stores_controller.rb
+++ b/app/controllers/stores_controller.rb
@@ -6,6 +6,7 @@ class StoresController < ApplicationController
   end
 
   def show
+    @store = Store.find(params[:id])
   end
 
   def new

--- a/app/helpers/reviews_helper.rb
+++ b/app/helpers/reviews_helper.rb
@@ -1,0 +1,2 @@
+module ReviewsHelper
+end

--- a/app/models/review.rb
+++ b/app/models/review.rb
@@ -1,0 +1,6 @@
+class Review < ApplicationRecord
+  belongs_to :user
+  belongs_to :store
+
+  validates :content, presence: true
+end

--- a/app/models/store.rb
+++ b/app/models/store.rb
@@ -70,4 +70,7 @@ class Store < ApplicationRecord
   def self.kids_friendly_i18n(attr)
   I18n.t("activerecord.attributes.store.kids_friendly_labels.#{attr}", locale: :ja)
   end
+
+  #レビュー情報の関連付け
+  has_many :reviews, dependent: :destroy
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -14,4 +14,7 @@ class User < ApplicationRecord
     login = conditions.delete(:login)
     where(conditions.to_h).where([ "name = :value OR email = :value", { value: login } ]).first
   end
+
+  #レビュー情報を関連付け
+  has_many :reviews, dependent: :destroy
 end

--- a/app/views/reviews/new.html.erb
+++ b/app/views/reviews/new.html.erb
@@ -1,0 +1,10 @@
+<h2><%= @store.store_name %> へのレビュー投稿</h2>
+
+<%= form_with(model: [@store, @review], local: true) do |form| %>
+  <div class="mb-4">
+    <%= form.label :content, "レビュー内容" %><br>
+    <%= form.text_area :content, rows: 5, class: "w-full border rounded p-2" %>
+  </div>
+
+  <%= form.submit "投稿する", class: "bg-blue-600 text-white px-4 py-2 rounded" %>
+<% end %>

--- a/app/views/stores/index.html.erb
+++ b/app/views/stores/index.html.erb
@@ -6,11 +6,10 @@
 
 <div id="stores">
   <% @stores.each do |store| %>
-    <%= render store %>
-    <p>
-      <%= link_to "Show this store", store %>
-    </p>
+    <div class="border p-2 mb-2 rounded">
+      <h3 class="text-lg font-bold"><%= store.store_name %></h3>
+      <p><%= store.address %></p>
+      <%= link_to "店舗の詳細を見る", store_path(store), class: "text-blue-600 underline" %>
+    </div>
   <% end %>
 </div>
-
-<%= link_to "New store", new_store_path %>

--- a/app/views/stores/search_results.html.erb
+++ b/app/views/stores/search_results.html.erb
@@ -12,8 +12,13 @@
         <% Store.kids_friendly_attributes.each do |attr| %>
           <li><%= Store.kids_friendly_i18n(attr) %>: <%= store.send("#{attr}_i18n") || "未設定" %></li>
         <% end %>
-      </ul> <!-- ✅ 追加: ulを閉じる -->
-    </div> <!-- ✅ 追加: divを閉じる -->
+      </ul>
+
+      <!--詳細ページへのリンク-->
+      <p class="mt-2">
+        <%= link_to "店舗の詳細を見る", store_path(store), class: "text-blue-600 underline" %>
+      </p>
+    </div>
   <% end %>
 <% else %>
   <p>該当する店舗は見つかりませんでした。</p>

--- a/app/views/stores/show.html.erb
+++ b/app/views/stores/show.html.erb
@@ -1,10 +1,50 @@
-<p style="color: green"><%= notice %></p>
+<h1 class="text-2xl font-bold mb-4"><%= @store.store_name %></h1>
 
-<%= render @store %>
-
-<div>
-  <%= link_to "Edit this store", edit_store_path(@store) %> |
-  <%= link_to "Back to stores", stores_path %>
-
-  <%= button_to "Destroy this store", @store, method: :delete %>
+<!-- 基本情報 -->
+<div class="mb-4">
+  <p><strong>住所:</strong> <%= @store.address.presence || "未登録" %></p>
+  <p><strong>営業時間:</strong> <%= @store.hours.presence || "未登録" %></p>
 </div>
+
+<!-- 子連れ向け情報 -->
+<div class="mb-6">
+  <h2 class="text-xl font-semibold mb-2">子連れお役立ち情報</h2>
+  <ul class="list-disc ml-6">
+    <% Store.kids_friendly_attributes.each do |attr| %>
+      <li><%= Store.kids_friendly_i18n(attr) %>: <%= @store.send("#{attr}_i18n") || "未設定" %></li>
+    <% end %>
+  </ul>
+</div>
+
+<!-- 写真 -->
+<% if @store.image_url.present? %>
+  <div class="mb-6">
+    <h2 class="text-xl font-semibold mb-2">店舗写真</h2>
+    <img src="<%= @store.image_url %>" alt="店舗写真" class="rounded shadow w-full max-w-lg">
+  </div>
+<% end %>
+
+<h2 class="mt-8">レビュー</h2>
+
+<% if @store.reviews.any? %>
+  <ul class="space-y-3">
+    <% @store.reviews.each do |review| %>
+      <li class="p-3 border rounded bg-gray-100">
+        <strong><%= review.user.name %></strong><br>
+        <%= simple_format(review.content) %>
+      </li>
+    <% end %>
+  </ul>
+<% else %>
+  <p>まだレビューはありません。</p>
+<% end %>
+
+<% if user_signed_in? %>
+  <div class="mt-4">
+    <%= link_to "レビューを投稿する", new_store_review_path(@store),
+      class: "bg-blue-500 text-white px-4 py-2 rounded hover:bg-blue-600" %>
+  </div>
+<% else %>
+  <p class="mt-4">レビュー投稿にはログインが必要です。</p>
+  <%= link_to "ログイン", new_user_session_path, class: "underline text-blue-600" %>
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,6 +12,11 @@ Rails.application.routes.draw do
     collection do
       get :search
     end
+
+    #レビュー投稿機能をstoresにネスト（ログイン済ユーザーのみアクセス）
+    authenticate :user do
+      resources :reviews, only: [ :new, :create ]
+    end
   end
 
   # 管理者用（店舗管理）
@@ -19,10 +24,9 @@ Rails.application.routes.draw do
     resources :stores
   end
 
-  # ユーザー認証が必要な機能（お気に入り・レビューなど）
+  # ユーザー認証が必要な機能（お気に入り）
   authenticate :user do
-    resources :favorites, only: [ :create, :destroy ] # お気に入り機能（ログイン必須）
-    resources :reviews, only: [ :create, :destroy ]   # レビュー機能（ログイン必須）
+    resources :favorites, only: [ :create, :destroy ]
   end
 
   # Rails のヘルスチェック用

--- a/db/migrate/20250327155147_create_reviews.rb
+++ b/db/migrate/20250327155147_create_reviews.rb
@@ -1,0 +1,12 @@
+class CreateReviews < ActiveRecord::Migration[7.2]
+  def change
+    create_table :reviews do |t|
+      t.references :user, null: false, foreign_key: true
+      t.references :store, null: false, foreign_key: true
+      t.text :content
+      t.integer :rating
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,20 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_03_11_061916) do
+ActiveRecord::Schema[7.2].define(version: 2025_03_27_155147) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "reviews", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.bigint "store_id", null: false
+    t.text "content"
+    t.integer "rating"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["store_id"], name: "index_reviews_on_store_id"
+    t.index ["user_id"], name: "index_reviews_on_user_id"
+  end
 
   create_table "stores", force: :cascade do |t|
     t.string "store_name"
@@ -52,4 +63,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_03_11_061916) do
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
+
+  add_foreign_key "reviews", "stores"
+  add_foreign_key "reviews", "users"
 end

--- a/test/controllers/reviews_controller_test.rb
+++ b/test/controllers/reviews_controller_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class ReviewsControllerTest < ActionDispatch::IntegrationTest
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/fixtures/reviews.yml
+++ b/test/fixtures/reviews.yml
@@ -1,0 +1,13 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  user: one
+  store: one
+  content: MyText
+  rating: 1
+
+two:
+  user: two
+  store: two
+  content: MyText
+  rating: 1

--- a/test/models/review_test.rb
+++ b/test/models/review_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class ReviewTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
### 📝 概要
--- 
検索結果一覧かr亞店舗詳細ページへ推移するようにしました。
また、店舗詳細ページにレビュー欄、レビュー投稿欄を追加。
ログインユーザーのみ投稿可能です。

### 🛠 やったこと
---
✅ レビュー投稿機能の実装

・reviews_controller.rb に new, createアクションを追加
・routes.rb にて stores に reviews をネストし、authenticate :user によりログインユーザーのみ利用可能に設定
・stores/show.html.erb にレビュー一覧・レビュー投稿リンクを追加
・reviews/new.html.erb にレビュー投稿フォームを作成

### 🙋‍♂️ できるようになること
---
**👤 ユーザー**
・店舗詳細ページからレビューを確認できる
・「レビューを投稿する」リンクからレビューを投稿できる（ログイン必須）

### ✅ 動作確認
--- 
・店舗詳細ページにレビュー一覧が表示されている
・「レビューを投稿する」ボタンからフォームに遷移でき、投稿が可
・投稿後はそのレビューが一覧に表示されること
・未ログインユーザーには投稿フォームが表示されず、ログインページへのリンクが表示される

### 備考
--- 
・機能のみの実装のためUIは最後に整える
・レビューの編集、削除が行えるように今後改善する